### PR TITLE
Remove .inc from linguist stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.inc linguist-vendored


### PR DESCRIPTION
`.inc` files are used in PHP, so GitHub will mark this repo as PHP.
Adding it to `linguist-vendored` solves this.